### PR TITLE
Fix undefined behavior causing WAV files to be unrecognized

### DIFF
--- a/src/brr_encoder.c
+++ b/src/brr_encoder.c
@@ -411,8 +411,7 @@ int main(const int argc, char *const argv[])
 	{
 		char chunk_ID[4];				// Should be 'RIFF'
 		u32 chunk_size;
-		char wave_str[4];				// Should be 'WAVE'
-		char sc1_id[4];					// Should be 'fmt '
+		char wave_sc1[8];				// Should be 'WAVEfmt '
 		u32 sc1size;					// Should be at least 16
 		u16 audio_format;				// Should be 1 for PCM
 		u16 chans;						// 1 for mono, 2 for stereo, etc...
@@ -439,7 +438,7 @@ int main(const int argc, char *const argv[])
 		exit(1);
 	}
 	// "WAVEfmt" letters
-	if(strncmp(hdr.wave_str, "WAVEfmt ", 8))
+	if(strncmp(hdr.wave_sc1, "WAVEfmt ", 8))
 	{
 		fprintf(stderr, "Input file in unsupported format : \"WAVEfmt\" block missing !\n");
 		exit(1);


### PR DESCRIPTION
`gcc (GCC) 11.2.0` produced a binary which treated even valid .wav files as `Input file in unsupported format : "WAVEfmt" block missing !`. This change fixes that.

This is the minimum work necessary to make the project build and run; it seems to work in practice. There's still some compiler warnings left, and maybe UB-type bugs in the code as well (I didn't test valgrind/asan yet). Also, IIRC the BRR decoder is incorrect and causes the encoder to generate incorrect BRR files in some edge cases, which decode properly in brr_decoder but not in accurate emulators (in rare circumstances, eg. when Gaussian filtering or resampling produces internal values beyond ±32k), probably related to #13.