### PR TITLE
Broken string comparison

### DIFF
--- a/src/brr_encoder.c
+++ b/src/brr_encoder.c
@@ -438,10 +438,11 @@ int main(const int argc, char *const argv[])
 		fprintf(stderr, "Error : Input file in unsupported format : \"RIFF\" block missing.\n");
 		exit(1);
 	}
-	// "WAVEfmt" letters
-	if(strncmp(hdr.wave_str, "WAVEfmt ", 8))
+	// "WAVEfmt " letters
+	if(strncmp(hdr.wave_str, "WAVE", 4) || 
+	   strncmp(hdr.sc1_id, "fmt ", 4))
 	{
-		fprintf(stderr, "Input file in unsupported format : \"WAVEfmt\" block missing !\n");
+		fprintf(stderr, "Input file in unsupported format : \"WAVEfmt \" block missing !\n");
 		exit(1);
 	}
 


### PR DESCRIPTION
The encoder was misbehaving and turns out it was doing a 8 bytes string comparison on two consecutive 4 byte char arrays that broke when -O3 made GCC optimize the code. 